### PR TITLE
[FEATURE] like crud

### DIFF
--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/book/entity/Chapter.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/book/entity/Chapter.java
@@ -33,7 +33,7 @@ public class Chapter extends BaseTimeEntity{
     // ※주의※ : Java의 List<Double>과 PostgreSQL의 VECTOR 타입은 자동으로 매핑되지 않는 경우가 많습니다.
     // 해결책: 만약 실행 시 에러가 난다면, hibernate-vector 라이브러리를 의존성에 추가하고 아래 어노테이션을 붙여야 합니다.
     @JdbcTypeCode(SqlTypes.VECTOR) // 이 부분이 필요할 수 있음
-    @Column(name = "vector", columnDefinition = "VECTOR(1536)")
+    @Column(name = "chapter_vector", columnDefinition = "VECTOR(1024)")
     private List<Double> vector;
 
     @Builder

--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/controller/LikeController.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/controller/LikeController.java
@@ -1,4 +1,44 @@
 package com.ohgiraffers.backendapi.domain.like.controller;
 
+import com.ohgiraffers.backendapi.domain.like.dto.LikeRequestDTO;
+import com.ohgiraffers.backendapi.domain.like.dto.LikeResponseDTO;
+import com.ohgiraffers.backendapi.domain.like.service.LikeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/likes")
+@RequiredArgsConstructor
+@Tag(name = "Like (좋아요/싫어요)", description = "댓글 및 리뷰에 대한 좋아요/싫어요 기능 API")
 public class LikeController {
+
+    private final LikeService likeService;
+
+    @Operation(summary = "댓글 좋아요/싫어요 토글")
+    @PostMapping("/comments/{commentId}")
+    public ResponseEntity<LikeResponseDTO> toggleCommentLike(
+            @Parameter(description = "대상 댓글 ID") @PathVariable Long commentId,
+            @RequestBody LikeRequestDTO likeRequestDTO
+            /* , @AuthenticationPrincipal Long userId */
+            ) {
+        Long tempUserId = 1L; // 임시 유저 ID(나중에 로그인 기능 구현되면 지울 것
+        LikeResponseDTO response = likeService.toggleCommentLike(tempUserId, commentId, likeRequestDTO.getLikeType());
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "리뷰 좋아요/싫어요 토글")
+    @PostMapping("/reviews/{reviewId}")
+    public ResponseEntity<LikeResponseDTO> toggleReviewLike(
+            @Parameter(description = "대상 댓글 ID") @PathVariable Long reviewId,
+            @RequestBody LikeRequestDTO likeRequestDTO
+            /* , @AuthenticationPrincipal Long userId */
+            ) {
+        Long tempUserId = 1L; // 임시 유저 ID(나중에 로그인 기능 구현되면 지우고 밑의 파라미터도 변경할 것
+        LikeResponseDTO response = likeService.toggleReviewLike(tempUserId, reviewId, likeRequestDTO.getLikeType());
+        return ResponseEntity.ok(response);
+    }
 }

--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/controller/LikeController.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/controller/LikeController.java
@@ -1,0 +1,4 @@
+package com.ohgiraffers.backendapi.domain.like.controller;
+
+public class LikeController {
+}

--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/dto/LikeRequestDTO.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/dto/LikeRequestDTO.java
@@ -1,0 +1,17 @@
+package com.ohgiraffers.backendapi.domain.like.dto;
+
+import com.ohgiraffers.backendapi.domain.like.enums.LikeType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "좋아요/싫어요 요청 DTO")
+public class LikeRequestDTO {
+
+    @Schema(description = "반응 유형 'LIKE'or'DISLIKE'", example = "LIKE")
+    @NotNull(message = "반응 유형은 필수입니다.")
+    private LikeType likeType;
+}

--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/dto/LikeResponseDTO.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/dto/LikeResponseDTO.java
@@ -1,0 +1,18 @@
+package com.ohgiraffers.backendapi.domain.like.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "좋아요 처리 결과 및 집계 DTO")
+public class LikeResponseDTO {
+    private boolean isPressed;
+    @Schema(description = "처리 메시지", example = "좋아요가 반영되었습니다.")
+    private String message;
+    private Long totalLikes;
+    private Long totalDislikes;
+}

--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/entity/Like.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/entity/Like.java
@@ -22,30 +22,30 @@ public class Like extends BaseTimeEntity {
     private Long likeId;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
-    private Comment commentId;
+    private Comment comment;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
-    private Review reviewId;
+    private Review review;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private User userId;
+    private User user;
     @Enumerated(EnumType.STRING)
     @Column(name = "reaction_type", nullable = false, length = 10)
     private LikeType likeType;
 
-    // 1. 댓글 좋아요 빌더
+    // 1. 댓글 좋아요 빌더(Service의 Helper Method의 saveCommentLike에서 사용함)
     @Builder(builderMethodName = "createCommentLike")
-    public Like(Comment commentId, User userId, LikeType likeType) {
-        this.commentId = commentId;
-        this.userId = userId;
+    public Like(Comment comment, User user, LikeType likeType) {
+        this.comment = comment;
+        this.user = user;
         this.likeType = likeType;
     }
 
-    // 2. 리뷰 좋아요 빌더
+    // 2. 리뷰 좋아요 빌더(위와 동일)
     @Builder(builderMethodName = "createReviewLike")
-    public Like(Review reviewId, User userId, LikeType likeType) {
-        this.reviewId = reviewId;
-        this.userId = userId;
+    public Like(Review review, User user, LikeType likeType) {
+        this.review = review;
+        this.user = user;
         this.likeType = likeType;
     }
 }

--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/repository/LikeRepository.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/repository/LikeRepository.java
@@ -1,0 +1,25 @@
+package com.ohgiraffers.backendapi.domain.like.repository;
+
+import com.ohgiraffers.backendapi.domain.like.entity.Like;
+import com.ohgiraffers.backendapi.domain.like.enums.LikeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    // [댓글 좋아요 토글]이미 좋아요를 눌렀는지 확인하여 (생성/취소) 분기 처리
+    Optional<Like> findByCommentId_CommentIdAndUserId_UserId(Long commentId, Long userId);
+
+    // [리뷰 좋아요 토글]이미 좋아요를 눌렀는지 확인하여 (생성/취소) 분기 처리
+    Optional<Like> findByReviewId_ReviewIdAndUserId_UserId(Long reviewId, Long user_Id);
+
+    // [댓글 좋아요 수 집계]특정 댓글의 총 좋아요 수를 실시간으로 계산
+    List<Like> countByCommentId_CommentIdAndLikeType(Long commentId, LikeType likeType);
+
+    // [리뷰 좋아요 수 집계]특정 댓글의 총 좋아요 수를 실시간으로 계산
+    List<Like> countByReviewId_ReviewIdAndLikeType(Long reviewId, LikeType likeType);
+}

--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/repository/LikeRepository.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/repository/LikeRepository.java
@@ -12,14 +12,14 @@ import java.util.Optional;
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
     // [댓글 좋아요 토글]이미 좋아요를 눌렀는지 확인하여 (생성/취소) 분기 처리
-    Optional<Like> findByCommentId_CommentIdAndUserId_UserId(Long commentId, Long userId);
+    Optional<Like> findByComment_CommentIdAndUser_UserId(Long commentId, Long userId);
 
     // [리뷰 좋아요 토글]이미 좋아요를 눌렀는지 확인하여 (생성/취소) 분기 처리
-    Optional<Like> findByReviewId_ReviewIdAndUserId_UserId(Long reviewId, Long user_Id);
+    Optional<Like> findByReview_ReviewIdAndUser_UserId(Long reviewId, Long userId);
 
     // [댓글 좋아요 수 집계]특정 댓글의 총 좋아요 수를 실시간으로 계산
-    List<Like> countByCommentId_CommentIdAndLikeType(Long commentId, LikeType likeType);
+    Long countByComment_CommentIdAndLikeType(Long commentId, LikeType likeType);
 
     // [리뷰 좋아요 수 집계]특정 댓글의 총 좋아요 수를 실시간으로 계산
-    List<Like> countByReviewId_ReviewIdAndLikeType(Long reviewId, LikeType likeType);
+    Long countByReview_ReviewIdAndLikeType(Long reviewId, LikeType likeType);
 }

--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/service/LikeService.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/service/LikeService.java
@@ -1,0 +1,44 @@
+package com.ohgiraffers.backendapi.domain.like.service;
+
+import com.ohgiraffers.backendapi.domain.comment.entity.Comment;
+import com.ohgiraffers.backendapi.domain.like.dto.LikeResponseDTO;
+import com.ohgiraffers.backendapi.domain.like.entity.Like;
+import com.ohgiraffers.backendapi.domain.like.enums.LikeType;
+import com.ohgiraffers.backendapi.domain.like.repository.LikeRepository;
+import com.ohgiraffers.backendapi.domain.user.entity.User;
+import com.ohgiraffers.backendapi.domain.user.repository.UserRepository;
+import com.ohgiraffers.backendapi.global.error.CustomException;
+import com.ohgiraffers.backendapi.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+//기존 내역 없음 -> 생성 (좋아요)
+//기존 내역 있음 + 같은 타입 -> 삭제 (취소)
+//기존 내역 있음 + 다른 타입 -> 변경 (좋아요 ↔ 싫어요 스위칭)
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+    private final ReviewRepository reviewRepository;
+
+    // [ 댓글 좋아요/싫어요 토글 ]
+    public LikeResponseDTO toggleCommentLike(Long userId, Long commentId, LikeType requestType) {
+
+        // 입력 값 검증(조회시 없으면 Exception)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 누른 적 있는지 확인
+        Optional<Like>
+    }
+}

--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/service/LikeService.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/domain/like/service/LikeService.java
@@ -5,6 +5,7 @@ import com.ohgiraffers.backendapi.domain.like.dto.LikeResponseDTO;
 import com.ohgiraffers.backendapi.domain.like.entity.Like;
 import com.ohgiraffers.backendapi.domain.like.enums.LikeType;
 import com.ohgiraffers.backendapi.domain.like.repository.LikeRepository;
+import com.ohgiraffers.backendapi.domain.review.entity.Review;
 import com.ohgiraffers.backendapi.domain.user.entity.User;
 import com.ohgiraffers.backendapi.domain.user.repository.UserRepository;
 import com.ohgiraffers.backendapi.global.error.CustomException;
@@ -39,6 +40,111 @@ public class LikeService {
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
 
         // 누른 적 있는지 확인
-        Optional<Like>
+        Optional<Like> existingLike = likeRepository.findByComment_CommentIdAndUser_UserId(commentId, userId);
+
+        boolean isPressed;
+        String message;
+
+        if (existingLike.isPresent()) {
+            // [A] 이미 Like 기록이 존재하는 경우
+            Like like = existingLike.get();
+
+            if(like.getLikeType() == requestType) {
+                // [A-1] 좋아요 상태에서 좋아요 클릭(중복 클릭) -> 좋아요 취소
+                likeRepository.delete(like);
+                isPressed = false;
+                message = "반응이 취소되었습니다.";
+            } else {
+                // [A-2] 좋아요 상태에서 싫어요 클릭(다른 것 클릭) -> 좋아요 타입 변경
+                likeRepository.delete(like);
+                saveCommentLike(user, comment, requestType);
+                isPressed = true;
+                message = requestType.getDescription() + "로 변경되었습니다.";
+            }
+        } else {
+            // [B] 처음 누른 경우 (생성)
+            saveCommentLike(user, comment, requestType);
+            isPressed = true;
+            message = requestType.getDescription() + "가 반영되었습니다.";
+        }
+
+        // 최신 집계 반환(좋아요 반영/해제 여부, 어떤것이 반영되었는지, 좋아요 합계, 싫어요 합계)
+        return buildResponse(isPressed, message,
+                likeRepository.countByComment_CommentIdAndLikeType(commentId, LikeType.LIKE),
+                likeRepository.countByComment_CommentIdAndLikeType(commentId, LikeType.DISLIKE));
+    }
+
+    // [ 리뷰 좋아요/싫어요 토글 ]
+    public LikeResponseDTO toggleReviewLike(Long userId, Long reviewId, LikeType requestType) {
+
+        // 입력 값 검증(조회시 없으면 Exception)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+
+        // 누른 적 있는지 확인
+        Optional<Like> existingLike = likeRepository.findByReview_ReviewIdAndUser_UserId(reviewId, userId);
+
+        boolean isPressed;
+        String message;
+
+        if (existingLike.isPresent()) {
+            // [A] 이미 Like 기록이 존재하는 경우
+            Like like = existingLike.get();
+
+            if(like.getLikeType() == requestType) {
+                // [A-1] 좋아요 상태에서 좋아요 클릭(중복 클릭) -> 좋아요 취소
+                likeRepository.delete(like);
+                isPressed = false;
+                message = "반응이 취소되었습니다.";
+            } else {
+                // [A-2] 좋아요 상태에서 싫어요 클릭(다른 것 클릭) -> 좋아요 타입 변경
+                likeRepository.delete(like);
+                saveReviewLike(user, review, requestType);
+                isPressed = true;
+                message = requestType.getDescription() + "로 변경되었습니다.";
+            }
+        } else {
+            // [B] 처음 누른 경우 (생성)
+            saveReviewLike(user, review, requestType);
+            isPressed = true;
+            message = requestType.getDescription() + "가 반영되었습니다.";
+        }
+
+        // 최신 집계 반환(좋아요 반영/해제 여부, 어떤것이 반영되었는지, 좋아요 합계, 싫어요 합계)
+        return buildResponse(isPressed, message,
+                likeRepository.countByReview_ReviewIdAndLikeType(reviewId, LikeType.LIKE),
+                likeRepository.countByReview_ReviewIdAndLikeType(reviewId, LikeType.DISLIKE));
+    }
+
+
+
+    // ---------- Helper Method ----------
+    private void saveCommentLike(User user, Comment comment, LikeType type) {
+        Like newLike = Like.createCommentLike()
+                .user(user)
+                .comment(comment)
+                .likeType(type)
+                .build();
+        likeRepository.save(newLike);
+    }
+
+    private void saveReviewLike(User user, Review review, LikeType type) {
+        Like newLike = Like.createReviewLike()
+                .user(user)
+                .review(review)
+                .likeType(type)
+                .build();
+        likeRepository.save(newLike);
+    }
+
+    private LikeResponseDTO buildResponse(boolean isPressed, String message, Long likes, Long dislikes) {
+        return LikeResponseDTO.builder()
+                .isPressed(isPressed)
+                .message(message)
+                .totalLikes(likes)
+                .totalDislikes(dislikes)
+                .build();
     }
 }

--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/global/error/ErrorCode.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/global/error/ErrorCode.java
@@ -5,7 +5,11 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-    CANNOT_REQUEST_TO_SELF(HttpStatus.BAD_REQUEST, "F001", "자기 자신에게는 친구 요청을 보낼 수 없습니다.");
+    CANNOT_REQUEST_TO_SELF(HttpStatus.BAD_REQUEST, "F001", "자기 자신에게는 친구 요청을 보낼 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "해당 댓글을 찾을 수 없습니다."),
+    REVIEW_NOR_FOUND(HttpStatus.NOT_FOUND, "R001", "해당 리뷰를 찾을 수 없습니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/backend-api/src/main/java/com/ohgiraffers/backendapi/global/error/ErrorCode.java
+++ b/backend-api/src/main/java/com/ohgiraffers/backendapi/global/error/ErrorCode.java
@@ -8,7 +8,7 @@ public enum ErrorCode {
     CANNOT_REQUEST_TO_SELF(HttpStatus.BAD_REQUEST, "F001", "자기 자신에게는 친구 요청을 보낼 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "해당 댓글을 찾을 수 없습니다."),
-    REVIEW_NOR_FOUND(HttpStatus.NOT_FOUND, "R001", "해당 리뷰를 찾을 수 없습니다.");
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "해당 리뷰를 찾을 수 없습니다.");
 
 
     private final HttpStatus status;


### PR DESCRIPTION
## 📌 개요
- 댓글과 리뷰에 대해 사용자가 '좋아요' 또는 '싫어요' 반응을 남길 수 있는 기능을 구현.
- 단순 생성/삭제가 아닌 토글(Toggle) 방식을 적용.

## 📝 작업 내용
- **Like 도메인 구축**: `Entity`, `Repository`, `Service`, `Controller`, `DTO` 구조 구현
- **토글(Toggle) 비즈니스 로직 구현**:
  - 기존 반응 없음 → **생성**
  - 동일한 반응 클릭 → **취소(삭제)**
  - 다른 반응 클릭 → **상태 변경 (예: 좋아요 ↔ 싫어요)**
- **API 엔드포인트 구현**:
  - `POST /api/v1/likes/comments/{commentId}`
  - `POST /api/v1/likes/reviews/{reviewId}`
- **예외 처리 추가**: `ErrorCode`에 유저, 댓글, 리뷰 관련 NOT_FOUND 에러 상수 추가
- **코드 개선**: Entity 필드명과 `@Builder` 파라미터를 객체 의미에 맞게 직관적으로 수정 (`userId` → `user`)

## 🔗 관련 이슈
- #17 
- Close #17 

## 🛠 이슈 체크리스트
- [x] Like 엔티티 및 Repository 설계 (BaseTimeEntity 상속)
- [x] 댓글 좋아요/싫어요 서비스 로직 구현 (생성, 취소, 변경)
- [x] 리뷰 좋아요/싫어요 서비스 로직 구현
- [x] 좋아요/싫어요 집계(Count) 기능 구현
- [x] API Controller 및 Swagger 명세 작성